### PR TITLE
Add libopus as a dependency of SDL2 audio.

### DIFF
--- a/Examples/Dialogs/Makefile
+++ b/Examples/Dialogs/Makefile
@@ -59,7 +59,7 @@ CXXFLAGS	:= $(CFLAGS) -fexceptions -std=gnu++17
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=${DEVKITPRO}/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lpu -lfreetype -lSDL2_mixer -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
+LIBS	:= -lpu -lfreetype -lSDL2_mixer -lopusfile -lopus -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Examples/GlobalInputs/Makefile
+++ b/Examples/GlobalInputs/Makefile
@@ -59,7 +59,7 @@ CXXFLAGS	:= $(CFLAGS) -fexceptions -std=gnu++17
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=${DEVKITPRO}/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lpu -lfreetype -lSDL2_mixer -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
+LIBS	:= -lpu -lfreetype -lSDL2_mixer -lopusfile -lopus -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Examples/LoopUpdating/Makefile
+++ b/Examples/LoopUpdating/Makefile
@@ -59,7 +59,7 @@ CXXFLAGS	:= $(CFLAGS) -fexceptions -std=gnu++17
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=${DEVKITPRO}/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lpu -lfreetype -lSDL2_mixer -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
+LIBS	:= -lpu -lfreetype -lSDL2_mixer -lopusfile -lopus -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Examples/SimpleApplication/Makefile
+++ b/Examples/SimpleApplication/Makefile
@@ -59,7 +59,7 @@ CXXFLAGS	:= $(CFLAGS) -fexceptions -std=gnu++17
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=${DEVKITPRO}/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lpu -lfreetype -lSDL2_mixer -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
+LIBS	:= -lpu -lfreetype -lSDL2_mixer -lopusfile -lopus -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It uses libnx and SDL2, so both libraries are required.
 To be more exact, this libraries should be installed via pacman:
 
 ```sh
-pacman -S switch-sdl2 switch-sdl2_ttf switch-sdl2_image switch-sdl2_gfx switch-sdl2_mixer switch-mesa switch-glad switch-glm switch-libdrm_nouveau switch-libwebp switch-libpng switch-freetype switch-bzip2 switch-libjpeg-turbo
+pacman -S switch-sdl2 switch-sdl2_ttf switch-sdl2_image switch-sdl2_gfx switch-sdl2_mixer switch-mesa switch-glad switch-glm switch-libdrm_nouveau switch-libwebp switch-libpng switch-freetype switch-bzip2 switch-libjpeg-turbo switch-opusfile switch-libopus
 ```
 
 ## Internal structure and performance
@@ -39,7 +39,7 @@ This is how a regular Plutonium project would (more or less) have its Makefile a
 ```Makefile
 ...
 
-LIBS := -lpu -lfreetype -lSDL2_mixer -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
+LIBS := -lpu -lfreetype -lSDL2_mixer -lopusfile -lopus -lmodplug -lmpg123 -lvorbisidec -logg -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2 -lEGL -lGLESv2 -lglapi -ldrm_nouveau -lwebp -lpng -ljpeg `sdl2-config --libs` `freetype-config --libs` -lnx
 LIBDIRS := $(PORTLIBS) $(LIBNX) $(CURDIR)/Plutonium
 
 ...


### PR DESCRIPTION
Otherwise we fail during the linking process

    linking SimpleApplication.elf
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: 
    C:/devkitPro/portlibs/switch/lib\libSDL2_mixer.a(music_opus.o): in function `OPUS_Load':
    music_opus.c:(.text.OPUS_Load+0x10): undefined reference to `op_open_callbacks'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x14): undefined reference to `op_free'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x18): undefined reference to `op_head'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x1c): undefined reference to `op_seekable'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x20): undefined reference to `op_open_callbacks'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x24): undefined reference to `op_read'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x28): undefined reference to `op_pcm_seek'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x2c): undefined reference to `op_free'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x30): undefined reference to `op_head'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x34): undefined reference to `op_seekable'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x3c): undefined reference to `op_read'
    c:/devkitpro/devkita64/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld.exe: music_opus.c:(.text.OPUS_Load+0x44): undefined reference to `op_pcm_seek'
    collect2.exe: error: ld returned 1 exit status
    make[1]: *** [/opt/devkitpro/libnx/switch_rules:80: /d/Dev/Plutonium/Examples/SimpleApplication/SimpleApplication.elf] Error 1
    make: *** [Makefile:165: Build] Error 2
