### PR TITLE
fix crash on initial render of an empty menu

### DIFF
--- a/Plutonium/Source/pu/ui/elm/elm_Menu.cpp
+++ b/Plutonium/Source/pu/ui/elm/elm_Menu.cpp
@@ -320,6 +320,7 @@ namespace pu::ui::elm
 
     void Menu::OnInput(u64 Down, u64 Up, u64 Held, bool Touch)
     {
+        if(GetItems().size() == 0) return;
         if(basestatus == 1)
         {
             auto curtime = std::chrono::steady_clock::now();


### PR DESCRIPTION
Because somehow an input slips through when switching layouts on button press.
This fixes the crash mentioned in goldleaf's readme.