### PR TITLE
fix build for new libnx pl changes

### DIFF
--- a/Plutonium/Source/pu/ui/render/render_SDL2.cpp
+++ b/Plutonium/Source/pu/ui/render/render_SDL2.cpp
@@ -37,7 +37,7 @@ namespace pu::ui::render
         PlFontData plfont;
         NativeFont font = NULL;
         SDL_RWops *mem = NULL;
-        Result rc = plGetSharedFontByType(&plfont, static_cast<s32>(Type));
+        Result rc = plGetSharedFontByType(&plfont, static_cast<PlSharedFontType>(Type));
         if(rc == 0)
         {
             mem = SDL_RWFromMem(plfont.address, plfont.size);


### PR DESCRIPTION
The newest libnx [changes](https://github.com/switchbrew/libnx/commit/d25144afbd6c7be049706448e856d921cb1926f3) enforce enforce enum for plGetSharedFontByType.

Should be changed before the next libnx release.