### PR TITLE
ui_types: Include array

### DIFF
--- a/Plutonium/include/pu/ui/ui_Types.hpp
+++ b/Plutonium/include/pu/ui/ui_Types.hpp
@@ -12,6 +12,7 @@
 */
 
 #pragma once
+#include <array>
 #include <pu/pu_Include.hpp>
 
 namespace pu::ui {


### PR DESCRIPTION
Fixes compilation error under ubuntu.

```
In file included from /home/narr/yuzu/uLaunch/Plutonium/Plutonium/include/pu/ttf/ttf_Font.hpp:4,
                 from /home/narr/yuzu/uLaunch/Plutonium/Plutonium/source/pu/ttf/ttf_Font.cpp:1:
/home/narr/yuzu/uLaunch/Plutonium/Plutonium/include/pu/ui/ui_Types.hpp:30:23: error: variable 'std::array<int, 4> pu::ui::DefaultFontSizes' has initializer but incomplete type
   30 |     static inline constexpr std::array<u32, static_cast<u32>(DefaultFontSize::Count)> DefaultFontSizes = { 18, 20, 25, 30 };
```
